### PR TITLE
Added prototype of Array.indexOf to fix break in IE

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -14,7 +14,7 @@
 	        return i;
 	      }
 	    }
-	    return false; //-1;
+	    return -1;
 	  }
 	}
 


### PR DESCRIPTION
Hi Matt,

I like your parser and came across this for a demo project I created for a YUI spreadsheet program that parses using your parser.  I was unable to get this working in IE because of it's lack of support for .indexOf, so I provided a prototype to add this at the top of the code.  

Hope this change is okay by you.  I am new to github and still learning the ropes.

Regards,
Todd
