### PR TITLE
fixing Functions are returned among variables()

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -284,10 +284,11 @@ var Parser = (function (scope) {
 
 		variables: function () {
 			var L = this.tokens.length;
+			var functions = [ "random","fac","min","max","pyt","pow","atan2"];
 			var vars = [];
 			for (var i = 0; i < L; i++) {
 				var item = this.tokens[i];
-				if (item.type_ === TVAR && (vars.indexOf(item.index_) == -1)) {
+				if (item.type_ === TVAR && (vars.indexOf(item.index_) == -1 && functions.indexOf(item.index_)==-1)) {
 					vars.push(item.index_);
 				}
 			}

--- a/parser.js
+++ b/parser.js
@@ -402,7 +402,7 @@ var Parser = (function (scope) {
 		};
 
 		this.consts = {
-			"E": Math.E,
+			"_E": Math.E,
 			"PI": Math.PI
 		};
 	}


### PR DESCRIPTION
It's evaluating properly. Tested for  cases like below

 var expr = Parser.parse("max(2 ^ x,10)");  // Returns an Expression object
 console.log(expr.evaluate({ x: 3 }));  // returns 10