### PR TITLE
First improvements

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -199,13 +199,17 @@ var Parser = (function (scope) { // eslint-disable-line no-unused-vars
           f = this.ops2[item.value];
           nstack.push(f(n1, n2));
         } else if (type === IVAR) {
-          if (hasValue(values, item.value)) {
-            nstack.push(getValue(values, item.value));
-          } else if (hasValue(this.functions, item.value)) {
-            nstack.push(getValue(this.functions, item.value));
-          } else {
-            throw new Error('undefined variable: ' + item.value);
-          }
+            if (item.value in this.functions) {
+                nstack.push(this.functions[item.value]);
+            }
+            else {
+                var v = getValue(values, item.value)
+                if (v !== undefined) {
+                    nstack.push(v);
+                } else {
+                    throw new Error('undefined variable: ' + item.value);
+                }
+            }
         } else if (type === IOP1) {
           n1 = nstack.pop();
           f = this.ops1[item.value];

--- a/parser.js
+++ b/parser.js
@@ -87,26 +87,16 @@ var Parser = (function (scope) { // eslint-disable-line no-unused-vars
   }
 
   function hasValue(values, index) {
-    var parts = index.split(/\./);
-    var value = values;
-    var part;
-    while ((part = parts.shift())) {
-      if (!(part in value)) {
-        return false;
-      }
-      value = value[part];
-    }
-    return true;
+      return (getValue(values, index) !== undefined);
   }
 
   function getValue(values, index) {
-    var parts = index.split(/\./);
-    var value = values;
-    var part;
-    while ((part = parts.shift())) {
-      value = value[part];
-    }
-    return value;
+      var val = true;
+      val = index.split(/\./).reduce(function index(o, i) {
+          return (o && (o[i] !== undefined)) ? o[i] : undefined;
+      }, values);
+
+      return val;
   }
 
   Expression.prototype = {


### PR DESCRIPTION
First improvements for performance decrease mentioned in #45 
- Functions defined within the library don't need the split-shift, since the object is flat.
- Only get value once and push it directly into nstack if available.