### PR TITLE
add typings, remove bloat

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*/
+!/dist
+!/typings.d.ts

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Mathematical expression evaluator",
   "main": "dist/bundle.js",
+  "typings": "parser.d.ts",
   "directories": {
     "test": "test"
   },

--- a/parser.d.ts
+++ b/parser.d.ts
@@ -1,0 +1,25 @@
+export type Value = number
+    | string
+    | ((...args: Value[]) => Value)
+    | { [propertyName: string]: Value };
+
+export interface Values {
+    [propertyName: string]: Value;
+}
+
+export class Parser {
+    constructor(options?: { allowMemberAccess?: boolean });
+    parse(expression: string): Expression;
+    evaluate(expression: string, values?: Value): number;
+    static parse(expression: string): Expression;
+    static evaluate(expression: string, values?: Value): number;
+}
+
+export interface Expression {
+    simplify(values?: Value): Expression;
+    evaluate(values?: Value): number;
+    substitute(values: Value): Expression;
+    symbols(): string[];
+    variables(): string[];
+    toJSFunction(params: string, values?: Value): (...args: any[]) => number;
+}


### PR DESCRIPTION
Typescript is becoming more and more popular, these are the typings we created and are currently available via `@types/expr-eval`, adding these to your project eases development a little.

I also cleaned up the packaged files, usually test and build files are not required when installing a package via npm eg. as a dependency.