### PR TITLE
Add the operator "in"

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ f(), x.y              | Left          | Function call, property access
 ==, !=, >=, <=, >, <  | Left          | Equals, not equals, etc.
 and                   | Left          | Logical AND
 or                    | Left          | Logical OR
+in                    | Left          | Is left operand is included in the right one?
 x ? y : z             | Right         | Ternary conditional (if x then y else z)
 
 #### Unary operators

--- a/src/functions.js
+++ b/src/functions.js
@@ -54,12 +54,9 @@ export function orOperator(a, b) {
   return Boolean(a || b);
 }
 
+import contains from './contains';
 export function inOperator(a, b) {
-  if (!b['indexOf']) {
-    // b is not like an array
-    return false;
-  }
-  return b.indexOf(a) != -1;
+  return contains(b, a);
 }
 
 export function sinh(a) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -54,6 +54,14 @@ export function orOperator(a, b) {
   return Boolean(a || b);
 }
 
+export function inOperator(a, b) {
+  if (!b['indexOf']) {
+    // b is not like an array
+    return false;
+  }
+  return b.indexOf(a) != -1;
+}
+
 export function sinh(a) {
   return ((Math.exp(a) - Math.exp(-a)) / 2);
 }

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -106,7 +106,7 @@ ParserState.prototype.parseAndExpression = function (instr) {
   }
 };
 
-var COMPARISON_OPERATORS = ['==', '!=', '<', '<=', '>=', '>'];
+var COMPARISON_OPERATORS = ['==', '!=', '<', '<=', '>=', '>', 'in'];
 
 ParserState.prototype.parseComparison = function (instr) {
   this.parseAddSub(instr);

--- a/src/parser.js
+++ b/src/parser.js
@@ -17,6 +17,7 @@ import {
   lessThanEqual,
   andOperator,
   orOperator,
+  inOperator,
   sinh,
   cosh,
   tanh,
@@ -83,7 +84,8 @@ export function Parser(options) {
     '>=': greaterThanEqual,
     '<=': lessThanEqual,
     and: andOperator,
-    or: orOperator
+    or: orOperator,
+    'in': inOperator
   };
 
   this.ternaryOps = {

--- a/test/operators.js
+++ b/test/operators.js
@@ -176,6 +176,32 @@ describe('Operators', function () {
     });
   });
 
+  describe('in operator', function () {
+    it("'a' in ['a', 'b']", function () {
+      expect(Parser.evaluate("'a' in toto", {"toto": ['a', 'b']})).to.equal(true);
+    });
+
+    it("'a' in ['b', 'a']", function () {
+      expect(Parser.evaluate("'a' in toto", {"toto": ['b', 'a']})).to.equal(true);
+    });
+
+    it("3 in [4, 3]", function () {
+      expect(Parser.evaluate("3 in toto", {"toto": [4, 3]})).to.equal(true);
+    });
+
+    it("'c' in ['a', 'b']", function () {
+      expect(Parser.evaluate("'c' in toto", {"toto": ['a', 'b']})).to.equal(false);
+    });
+
+    it("'c' in ['b', 'a']", function () {
+      expect(Parser.evaluate("'c' in toto", {"toto": ['b', 'a']})).to.equal(false);
+    });
+
+    it("3 in [1, 2]", function () {
+      expect(Parser.evaluate("3 in toto", {"toto": [1, 2]})).to.equal(false);
+    });
+  });
+
   describe('not operator', function () {
     it('not 1', function () {
       expect(Parser.evaluate('not 1')).to.equal(false);


### PR DESCRIPTION
This new operator is usefull to test if the left operand is included in the right one.

The current implementation works only if the right operand is a variable, as expr-eval is not able to parse array syntax.

It may work against a string, but this behavior is not tested.