### PR TITLE
[Proposal] .variables()/.symbols() output might contain members

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -35,15 +35,17 @@ Expression.prototype.toString = function () {
   return expressionToString(this.tokens, false);
 };
 
-Expression.prototype.symbols = function () {
+Expression.prototype.symbols = function (with_members) {
+  with_members = with_members || false;
   var vars = [];
-  getSymbols(this.tokens, vars);
+  getSymbols(this.tokens, vars, with_members);
   return vars;
 };
 
-Expression.prototype.variables = function () {
+Expression.prototype.variables = function (with_members) {
+  with_members = with_members || false;
   var vars = [];
-  getSymbols(this.tokens, vars);
+  getSymbols(this.tokens, vars, with_members);
   var functions = this.functions;
   return vars.filter(function (name) {
     return !(name in functions);

--- a/src/expression.js
+++ b/src/expression.js
@@ -35,17 +35,17 @@ Expression.prototype.toString = function () {
   return expressionToString(this.tokens, false);
 };
 
-Expression.prototype.symbols = function (with_members) {
-  with_members = with_members || false;
+Expression.prototype.symbols = function (options) {
+  options = options || {}
   var vars = [];
-  getSymbols(this.tokens, vars, with_members);
+  getSymbols(this.tokens, vars, options);
   return vars;
 };
 
-Expression.prototype.variables = function (with_members) {
-  with_members = with_members || false;
+Expression.prototype.variables = function (options) {
+  options = options || {}
   var vars = [];
-  getSymbols(this.tokens, vars, with_members);
+  getSymbols(this.tokens, vars, options);
   var functions = this.functions;
   return vars.filter(function (name) {
     return !(name in functions);

--- a/src/get-symbols.js
+++ b/src/get-symbols.js
@@ -1,13 +1,25 @@
-import { IVAR, IEXPR } from './instruction';
+import { IVAR, IMEMBER, IEXPR } from './instruction';
 import contains from './contains';
 
-export default function getSymbols(tokens, symbols) {
+export default function getSymbols(tokens, symbols, with_members) {
+  var hold_var = null;
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     if (item.type === IVAR && !contains(symbols, item.value)) {
-      symbols.push(item.value);
+      if (hold_var !== null || !with_members) {
+        symbols.push(item.value);
+      } else {
+        hold_var = item.value;
+      }
+    } else if (item.type === IMEMBER && with_members && hold_var !== null) {
+      hold_var += '.' + item.value;
     } else if (item.type === IEXPR) {
-      getSymbols(item.value, symbols);
+      getSymbols(item.value, symbols, with_members);
+    } else if (hold_var !== null) {
+      if (!contains(symbols, hold_var)) {
+        symbols.push(hold_var);
+      }
+      hold_var = null;
     }
   }
 }

--- a/src/get-symbols.js
+++ b/src/get-symbols.js
@@ -1,25 +1,28 @@
 import { IVAR, IMEMBER, IEXPR } from './instruction';
 import contains from './contains';
 
-export default function getSymbols(tokens, symbols, with_members) {
-  var hold_var = null;
+export default function getSymbols(tokens, symbols, options) {
+  options = options || {};
+  var withMembers = !!options.withMembers;
+  var prevVar = null;
+
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     if (item.type === IVAR && !contains(symbols, item.value)) {
-      if (hold_var !== null || !with_members) {
+      if (prevVar !== null || !withMembers) {
         symbols.push(item.value);
       } else {
-        hold_var = item.value;
+        prevVar = item.value;
       }
-    } else if (item.type === IMEMBER && with_members && hold_var !== null) {
-      hold_var += '.' + item.value;
+    } else if (item.type === IMEMBER && withMembers && prevVar !== null) {
+      prevVar += '.' + item.value;
     } else if (item.type === IEXPR) {
-      getSymbols(item.value, symbols, with_members);
-    } else if (hold_var !== null) {
-      if (!contains(symbols, hold_var)) {
-        symbols.push(hold_var);
+      getSymbols(item.value, symbols, options);
+    } else if (prevVar !== null) {
+      if (!contains(symbols, prevVar)) {
+        symbols.push(prevVar);
       }
-      hold_var = null;
+      prevVar = null;
     }
   }
 }

--- a/test/expression.js
+++ b/test/expression.js
@@ -217,6 +217,15 @@ describe('Expression', function () {
     it('a or b ? c + d : e * f', function () {
       expect(Parser.parse('a or b ? c + d : e * f').symbols()).to.include.members(['a', 'b', 'c', 'd', 'e', 'f']);
     });
+
+    it('user.age + 2', function () {
+      expect(Parser.parse('user.age + 2').symbols()).to.include.members(['user']);
+    });
+
+    it('user.age + 2 with { withMembers: true } option', function () {
+      var expr = Parser.parse('user.age + 2')
+      expect(expr.symbols({ withMembers: true })).to.include.members(['user.age']);
+    });
   });
 
   describe('toString()', function () {


### PR DESCRIPTION
Before all, this PR is opened for discussion and reviewing. It is not intended to be merged as this.

This PR add the possibility to extract full variable names (including members…) from a formula when using the `.variables()` or `.symbols()` method call.

My use case is the following. In my project, I use complex javascript objects like this

```javascript
user = {
  firstname: 'toto',
  lastname: 'tata'
}
```

I use expr-eval as a little parser to understand display conditions stored in custom html attributes:

```html
<div data-display-only="user.firstname == 'toto'" id="testdiv">
  Hello toto
</div>
```

A problem occurs when I want to do some introspection on my formula:

```javascript
pp = Parser.parse(document.getElementById('testdiv').getAttribute('data-display-only'));
console.log(pp.variables())
```

I expect the following to be displayed: `[user.firstname]`, but instead I got `[user]`. Because `.firstname` is recognized as an `IMEMBER`, which is not output by `.variables()`.

My proposal is to pass a simple boolean to `.variables` or `.symbols` to add the members to their related variables if any. The default behavior stay the same (do not output members).

- Do you find my use case pertinent/interesting or too specific?
- Does my implementation seems right to you or does it feels like an ugly monkeypatch?