### PR TITLE
Add 'contains' operator directly

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -58,6 +58,7 @@ import contains from './contains';
 export function inOperator(a, b) {
   return contains(b, a);
 }
+export contains;
 
 export function sinh(a) {
   return ((Math.exp(a) - Math.exp(-a)) / 2);

--- a/src/functions.js
+++ b/src/functions.js
@@ -58,7 +58,7 @@ import contains from './contains';
 export function inOperator(a, b) {
   return contains(b, a);
 }
-export contains;
+export { contains };
 
 export function sinh(a) {
   return ((Math.exp(a) - Math.exp(-a)) / 2);

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -106,7 +106,7 @@ ParserState.prototype.parseAndExpression = function (instr) {
   }
 };
 
-var COMPARISON_OPERATORS = ['==', '!=', '<', '<=', '>=', '>', 'in'];
+var COMPARISON_OPERATORS = ['==', '!=', '<', '<=', '>=', '>', 'in', 'contains'];
 
 ParserState.prototype.parseComparison = function (instr) {
   this.parseAddSub(instr);

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,7 @@ import {
   andOperator,
   orOperator,
   inOperator,
+  contains,
   sinh,
   cosh,
   tanh,
@@ -85,7 +86,8 @@ export function Parser(options) {
     '<=': lessThanEqual,
     and: andOperator,
     or: orOperator,
-    'in': inOperator
+    'in': inOperator,
+    contains: contains
   };
 
   this.ternaryOps = {

--- a/test/operators.js
+++ b/test/operators.js
@@ -201,6 +201,32 @@ describe('Operators', function () {
       expect(Parser.evaluate("3 in toto", {"toto": [1, 2]})).to.equal(false);
     });
   });
+  
+  describe('contains operator', function () {
+    it("['a', 'b'] contains 'a'", function () {
+      expect(Parser.evaluate("toto contains 'a'", {"toto": ['a', 'b']})).to.equal(true);
+    });
+
+    it("['b', 'a'] contains 'a'", function () {
+      expect(Parser.evaluate("toto contains 'a'", {"toto": ['b', 'a']})).to.equal(true);
+    });
+
+    it("[4, 3] contains 3", function () {
+      expect(Parser.evaluate("toto contains 3", {"toto": [4, 3]})).to.equal(true);
+    });
+
+    it("['a', 'b'] contains 'c'", function () {
+      expect(Parser.evaluate("toto contains 'c'", {"toto": ['a', 'b']})).to.equal(false);
+    });
+
+    it("['b', 'a'] contains 'c'", function () {
+      expect(Parser.evaluate("toto contains 'c'", {"toto": ['b', 'a']})).to.equal(false);
+    });
+
+    it("[1, 2] contains 3", function () {
+      expect(Parser.evaluate("toto contains 3", {"toto": [1, 2]})).to.equal(false);
+    });
+  });
 
   describe('not operator', function () {
     it('not 1', function () {


### PR DESCRIPTION
When converting some code over from some different libraries to use `expr-eval`, I ran into a common case with evaluating against array members.

There is a merged pull request that added an `in` operator, but the issue there is its inverted from how normal logic flow works (its yoda-ish). With that in mind, I would like to lobby for a direct `contains` operator.

Compare:
`'a' in ['a', 'b']`
vs
`['a','b'] contains 'a'`

The second is a much more obvious and logical way of doing this comparison. I piggybacked off of all the work to add `in` and just made a version that uses `contains` directly. 

Tests are also added.