### PR TITLE
getSymbols using withMembers gives the wrong names for [ IVAR, IVAR ]

### DIFF
--- a/src/get-symbols.js
+++ b/src/get-symbols.js
@@ -9,8 +9,13 @@ export default function getSymbols(tokens, symbols, options) {
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     if (item.type === IVAR && !contains(symbols, item.value)) {
-      if (prevVar !== null || !withMembers) {
+      if (!withMembers) {
         symbols.push(item.value);
+      } else if (prevVar !== null) {
+        if (!contains(symbols, prevVar)) {
+          symbols.push(prevVar);
+        }
+        prevVar = item.value;
       } else {
         prevVar = item.value;
       }

--- a/test/expression.js
+++ b/test/expression.js
@@ -106,6 +106,14 @@ describe('Expression', function () {
     it('$x * $y_+$a1*$z - $b2', function () {
       expect(Parser.evaluate('$x * $y_+$a1*$z - $b2', { $a1: 3, $b2: 5, $x: 7, $y_: 9, $z: 11 })).to.equal(91);
     });
+
+    it('max(conf.limits.lower, conf.limits.upper)', function () {
+        expect(Parser.evaluate('max(conf.limits.lower, conf.limits.upper)', { conf: { limits: { lower: 4, upper: 9 } } })).to.equal(9);
+    });
+
+    it('fn.max(conf.limits.lower, conf.limits.upper)', function () {
+        expect(Parser.evaluate('fn.max(conf.limits.lower, conf.limits.upper)', { fn: { max: Math.max }, conf: { limits: { lower: 4, upper: 9 } } })).to.equal(9);
+    });
   });
 
   describe('substitute()', function () {
@@ -233,6 +241,26 @@ describe('Expression', function () {
     it('x with { withMembers: false } option', function () {
       var expr = Parser.parse('x');
       expect(expr.variables({ withMembers: false })).to.include.members(['x']);
+    });
+
+    it('max(conf.limits.lower, conf.limits.upper) with { withMembers: false } option', function () {
+        var expr = Parser.parse('max(conf.limits.lower, conf.limits.upper)');
+        expect(expr.variables({ withMembers: false })).to.include.members(['conf']);
+    });
+
+    it('max(conf.limits.lower, conf.limits.upper) with { withMembers: true } option', function () {
+        var expr = Parser.parse('max(conf.limits.lower, conf.limits.upper)');
+        expect(expr.variables({ withMembers: true })).to.include.members(['conf.limits.lower', 'conf.limits.upper']);
+    });
+
+    it('fn.max(conf.limits.lower, conf.limits.upper) with { withMembers: false } option', function () {
+        var expr = Parser.parse('fn.max(conf.limits.lower, conf.limits.upper)');
+        expect(expr.variables({ withMembers: false })).to.include.members(['fn', 'conf']);
+    });
+
+    it('fn.max(conf.limits.lower, conf.limits.upper) with { withMembers: true } option', function () {
+        var expr = Parser.parse('fn.max(conf.limits.lower, conf.limits.upper)');
+        expect(expr.variables({ withMembers: true })).to.include.members(['fn.max', 'conf.limits.lower', 'conf.limits.upper']);
     });
   });
 


### PR DESCRIPTION
When `getSymbols` is called using `withMembers == true`, the value of `prevVar` is inappropriately preserved across symbols when `IVARs` follow one another in the token stream (with optional `IMEMBERs`). When member access is involved, this results in the wrong names being returned from `getSymbols`, e.g. `Parser.parse("max(conf.limits.lower, conf.limits.upper)").variables({ withMembers: true })` gives `[ 'conf', 'max.limits.lower' ]`.

Even when member access isn't involved (e.g. `max(lower, upper)`), the sequence of events is:

1. Assign max to `prevVar`
2. Push lower to `symbols`
3. Push upper to `symbols`
4. Push `prevVar` (containing max) to `symbols` on encountering the `call` token

The preservation of `prevVar` from step 1 all the way to step 4, along with the fact that symbols end up being pushed out of order, makes it look like the correct result might be accidental.

Expression evaluation doesn't appear to be affected - just constructing the set of symbols/variables.