### PR TITLE
Improved how expressions are simplified to eliminate sub-expressions that can be evaluated

### DIFF
--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,57 +1,63 @@
 import { Instruction, INUMBER, IOP1, IOP2, IOP3, IVAR, IEXPR, IMEMBER } from './instruction';
 
 export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values) {
-  var nstack = [];
-  var newexpression = [];
-  var n1, n2, n3;
-  var f;
-  for (var i = 0; i < tokens.length; i++) {
-    var item = tokens[i];
-    var type = item.type;
-    if (type === INUMBER) {
-      nstack.push(item);
-    } else if (type === IVAR && values.hasOwnProperty(item.value)) {
-      item = new Instruction(INUMBER, values[item.value]);
-      nstack.push(item);
-    } else if (type === IOP2 && nstack.length > 1) {
-      n2 = nstack.pop();
-      n1 = nstack.pop();
-      f = binaryOps[item.value];
-      item = new Instruction(INUMBER, f(n1.value, n2.value));
-      nstack.push(item);
-    } else if (type === IOP3 && nstack.length > 2) {
-      n3 = nstack.pop();
-      n2 = nstack.pop();
-      n1 = nstack.pop();
-      if (item.value === '?') {
-        nstack.push(n1.value ? n2.value : n3.value);
-      } else {
-        f = ternaryOps[item.value];
-        item = new Instruction(INUMBER, f(n1.value, n2.value, n3.value));
+    var nstack = [];
+    var newexpression = [];
+    var n1, n2, n3;
+    var f;
+    for (var i = 0; i < tokens.length; i++) {
+      var item = tokens[i];
+      var type = item.type;
+      if (type === INUMBER) {
         nstack.push(item);
+      } else if (type === IVAR && values.hasOwnProperty(item.value)) {
+        item = new Instruction(INUMBER, values[item.value]);
+        nstack.push(item);
+      } else if (type === IOP2 && nstack.length > 1) {
+        n2 = nstack.pop();
+        n1 = nstack.pop();
+        f = binaryOps[item.value];
+        item = new Instruction(INUMBER, f(n1.value, n2.value));
+        nstack.push(item);
+      } else if (type === IOP3 && nstack.length > 2) {
+        n3 = nstack.pop();
+        n2 = nstack.pop();
+        n1 = nstack.pop();
+        if (item.value === '?') {
+          nstack.push(n1.value ? n2.value : n3.value);
+        } else {
+          f = ternaryOps[item.value];
+          item = new Instruction(INUMBER, f(n1.value, n2.value, n3.value));
+          nstack.push(item);
+        }
+      } else if (type === IOP1 && nstack.length > 0) {
+        n1 = nstack.pop();
+        f = unaryOps[item.value];
+        item = new Instruction(INUMBER, f(n1.value));
+        nstack.push(item);
+      } else if (type === IEXPR) {
+      var simplified = simplify(item.value, unaryOps, binaryOps, ternaryOps, values);
+      if(simplified.length === 1 && simplified[0].type === INUMBER) {
+        nstack.push(simplified[0]);
       }
-    } else if (type === IOP1 && nstack.length > 0) {
-      n1 = nstack.pop();
-      f = unaryOps[item.value];
-      item = new Instruction(INUMBER, f(n1.value));
-      nstack.push(item);
-    } else if (type === IEXPR) {
-      while (nstack.length > 0) {
-        newexpression.push(nstack.shift());
+      else {
+        while (nstack.length > 0) {
+          newexpression.push(nstack.shift());
+        }
+          newexpression.push(new Instruction(IEXPR, simplified));
+        }
+      } else if (type === IMEMBER && nstack.length > 0) {
+        n1 = nstack.pop();
+        nstack.push(new Instruction(INUMBER, n1.value[item.value]));
+      } else {
+        while (nstack.length > 0) {
+          newexpression.push(nstack.shift());
+        }
+        newexpression.push(item);
       }
-      newexpression.push(new Instruction(IEXPR, simplify(item.value, unaryOps, binaryOps, ternaryOps, values)));
-    } else if (type === IMEMBER && nstack.length > 0) {
-      n1 = nstack.pop();
-      nstack.push(new Instruction(INUMBER, n1.value[item.value]));
-    } else {
-      while (nstack.length > 0) {
-        newexpression.push(nstack.shift());
-      }
-      newexpression.push(item);
     }
+    while (nstack.length > 0) {
+      newexpression.push(nstack.shift());
+    }
+    return newexpression;
   }
-  while (nstack.length > 0) {
-    newexpression.push(nstack.shift());
-  }
-  return newexpression;
-}

--- a/test/expression.js
+++ b/test/expression.js
@@ -172,11 +172,11 @@ describe('Expression', function () {
     });
 
     it('x ? (y + 1) : z', function () {
-      assert.strictEqual(Parser.parse('x ? (y + 1) : z').simplify({ y: 2 }).toString(), '(x ? (3) : (z))');
+      assert.strictEqual(Parser.parse('x ? (y + 1) : z').simplify({ y: 2 }).toString(), '(x ? 3 : (z))');
     });
 
     it('x ? y : (z * 4)', function () {
-      assert.strictEqual(Parser.parse('x ? y : (z * 4)').simplify({ z: 3 }).toString(), '(x ? (y) : (12))');
+      assert.strictEqual(Parser.parse('x ? y : (z * 4)').simplify({ z: 3 }).toString(), '(x ? (y) : 12)');
     });
   });
 


### PR DESCRIPTION
This pull request changes how the `simplify()` function works when dealing with expressions that can be simplified even further.

**Example 1:**
```javascript
true and true or true
```
Before the change, this would have evaluated to something like `true and (true or (true))`. Yet, since this is an expression that can already be simplified to a single literal, it now evaluates to:
```javascript
true
```

**Example 2:**
```javascript
(5 > 2) or x > 8
```
Now, when running `simplify()`, this will evaluate to `true or (x > 8)`. When running `simplify({x: 10})`, this will evaluate to `true`.