### PR TITLE
Fix withMembers not including all members in special cases

### DIFF
--- a/src/get-symbols.js
+++ b/src/get-symbols.js
@@ -8,8 +8,8 @@ export default function getSymbols(tokens, symbols, options) {
 
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
-    if (item.type === IVAR && !contains(symbols, item.value)) {
-      if (!withMembers) {
+    if (item.type === IVAR) {
+      if (!withMembers && !contains(symbols, item.value)) {
         symbols.push(item.value);
       } else if (prevVar !== null) {
         if (!contains(symbols, prevVar)) {

--- a/test/expression.js
+++ b/test/expression.js
@@ -220,6 +220,11 @@ describe('Expression', function () {
       assert.deepEqual(expr.variables({ withMembers: true }), ['x.y.z', 'default.z', 'x.y']);
     });
 
+    it('x + x.y + x.z with { withMembers: true } option', function () {
+      var expr = Parser.parse('x + x.y + x.z');
+      assert.deepEqual(expr.variables({ withMembers: true }), ['x', 'x.y', 'x.z']);
+    });
+
     it('x.y < 3 ? 2 * x.y.z : default.z + 1 with { withMembers: true } option', function () {
       var expr = Parser.parse('x.y < 3 ? 2 * x.y.z : default.z + 1');
       assert.deepEqual(expr.variables({ withMembers: true }), ['x.y', 'x.y.z', 'default.z']);


### PR DESCRIPTION
Particularly, the case `x + x.y + x.z` was not working before; it would only give back x and x.y.