### PR TITLE
Add variable assignment

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1,4 +1,4 @@
-import { INUMBER, IOP1, IOP2, IOP3, IVAR, IFUNCALL, IEXPR, IMEMBER } from './instruction';
+import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER } from './instruction';
 
 export default function evaluate(tokens, expr, values) {
   var nstack = [];
@@ -7,7 +7,7 @@ export default function evaluate(tokens, expr, values) {
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     var type = item.type;
-    if (type === INUMBER) {
+    if (type === INUMBER || type === IVARNAME) {
       nstack.push(item.value);
     } else if (type === IOP2) {
       n2 = nstack.pop();
@@ -16,6 +16,9 @@ export default function evaluate(tokens, expr, values) {
         nstack.push(n1 ? !!evaluate(n2, expr, values) : false);
       } else if (item.value === 'or') {
         nstack.push(n1 ? true : !!evaluate(n2, expr, values));
+      } else if (item.value === '=') {
+        f = expr.binaryOps[item.value];
+        nstack.push(f(n1, evaluate(n2, expr, values), values));
       } else {
         f = expr.binaryOps[item.value];
         nstack.push(f(n1, n2));

--- a/src/expression-to-string.js
+++ b/src/expression-to-string.js
@@ -1,4 +1,4 @@
-import { INUMBER, IOP1, IOP2, IOP3, IVAR, IFUNCALL, IEXPR, IMEMBER } from './instruction';
+import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER } from './instruction';
 
 export default function expressionToString(tokens, toJS) {
   var nstack = [];
@@ -46,7 +46,7 @@ export default function expressionToString(tokens, toJS) {
       } else {
         throw new Error('invalid Expression');
       }
-    } else if (type === IVAR) {
+    } else if (type === IVAR || type === IVARNAME) {
       nstack.push(item.value);
     } else if (type === IOP1) {
       n1 = nstack.pop();

--- a/src/functions.js
+++ b/src/functions.js
@@ -238,3 +238,8 @@ export function roundTo(value, exp) {
   value = value.toString().split('e');
   return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
 }
+
+export function setVar(name, value, variables) {
+  if (variables) variables[name] = value;
+  return value;
+}

--- a/src/instruction.js
+++ b/src/instruction.js
@@ -3,6 +3,7 @@ export var IOP1 = 'IOP1';
 export var IOP2 = 'IOP2';
 export var IOP3 = 'IOP3';
 export var IVAR = 'IVAR';
+export var IVARNAME = 'IVARNAME';
 export var IFUNCALL = 'IFUNCALL';
 export var IEXPR = 'IEXPR';
 export var IMEMBER = 'IMEMBER';
@@ -19,6 +20,7 @@ Instruction.prototype.toString = function () {
     case IOP2:
     case IOP3:
     case IVAR:
+    case IVARNAME:
       return this.value;
     case IFUNCALL:
       return 'CALL ' + this.value;

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -1,5 +1,5 @@
 import { TOP, TNUMBER, TSTRING, TPAREN, TCOMMA, TNAME } from './token';
-import { Instruction, INUMBER, IVAR, IFUNCALL, IEXPR, IMEMBER, ternaryInstruction, binaryInstruction, unaryInstruction } from './instruction';
+import { Instruction, INUMBER, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER, ternaryInstruction, binaryInstruction, unaryInstruction } from './instruction';
 import contains from './contains';
 
 export function ParserState(parser, tokenStream, options) {
@@ -74,6 +74,21 @@ ParserState.prototype.parseAtom = function (instr) {
 
 ParserState.prototype.parseExpression = function (instr) {
   this.parseConditionalExpression(instr);
+  this.parseVariableAssignmentExpression(instr);
+};
+
+ParserState.prototype.parseVariableAssignmentExpression = function (instr) {
+  while (this.accept(TOP, '=')) {
+    var varName = instr.pop();
+    var varValue = [];
+    if (varName.type !== IVAR) {
+      throw new Error('expected variable for assignment');
+    }
+    this.parseConditionalExpression(varValue);
+    instr.push(new Instruction(IVARNAME, varName.value));
+    instr.push(new Instruction(IEXPR, varValue));
+    instr.push(binaryInstruction('='));
+  }
 };
 
 ParserState.prototype.parseConditionalExpression = function (instr) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -34,7 +34,8 @@ import {
   stringLength,
   hypot,
   condition,
-  roundTo
+  roundTo,
+  setVar
 } from './functions';
 
 export function Parser(options) {
@@ -86,7 +87,8 @@ export function Parser(options) {
     '<=': lessThanEqual,
     and: andOperator,
     or: orOperator,
-    'in': inOperator
+    'in': inOperator,
+    '=': setVar
   };
 
   this.ternaryOps = {

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,4 +1,4 @@
-import { Instruction, INUMBER, IOP1, IOP2, IOP3, IVAR, IEXPR, IMEMBER } from './instruction';
+import { Instruction, INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IEXPR, IMEMBER } from './instruction';
 
 export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values) {
   var nstack = [];
@@ -8,7 +8,7 @@ export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     var type = item.type;
-    if (type === INUMBER) {
+    if (type === INUMBER || type === IVARNAME) {
       nstack.push(item);
     } else if (type === IVAR && values.hasOwnProperty(item.value)) {
       item = new Instruction(INUMBER, values[item.value]);

--- a/src/token-stream.js
+++ b/src/token-stream.js
@@ -383,7 +383,7 @@ TokenStream.prototype.isOperator = function () {
       this.current = this.newToken(TOP, '==');
       this.pos++;
     } else {
-      return false;
+      this.current = this.newToken(TOP, c);
     }
   } else if (c === '!') {
     if (this.expression.charAt(this.pos + 1) === '=') {
@@ -424,7 +424,8 @@ var optionNameMap = {
   'or': 'logical',
   'not': 'logical',
   '?': 'conditional',
-  ':': 'conditional'
+  ':': 'conditional',
+  '=': 'set'
 };
 
 function getOptionName(op) {

--- a/test/expression.js
+++ b/test/expression.js
@@ -99,6 +99,16 @@ describe('Expression', function () {
       assert.throws(function () { Parser.evaluate('x + 1'); }, Error);
     });
 
+    it('x = 3 * 2 + 1', function () {
+      assert.strictEqual(Parser.evaluate('x = 3 * 2 + 1'), 7);
+    });
+
+    it('x = x * 2 + 1', function () {
+      var obj = {}
+      Parser.evaluate('x = 3 * 2 + 1', obj)
+      assert.strictEqual(Parser.evaluate('x = x * 2 + 1', obj), 15);
+    });
+
     it('should fail trying to call a non-function', function () {
       assert.throws(function () { Parser.evaluate('f()', { f: 2 }); }, Error);
     });
@@ -419,6 +429,10 @@ describe('Expression', function () {
         '((((a < b) or (((c > d) and ((e <= f))))) or (((g >= h) and ((i == j))))) or ((k != l)))');
     });
 
+    it('x = x + 1', function () {
+      assert.strictEqual(parser.parse('x = x + 1').toString(), '(x = ((x + 1)))');
+    });
+
     it('\'as\' || \'df\'', function () {
       assert.strictEqual(parser.parse('\'as\' || \'df\'').toString(), '("as" || "df")');
     });
@@ -452,6 +466,12 @@ describe('Expression', function () {
       var expr = parser.parse('x || y');
       var f = expr.toJSFunction('x, y');
       assert.strictEqual(f(4, 2), '42');
+    });
+
+    it('x = x + 1', function () {
+      var expr = parser.parse('x = x + 1');
+      var f = expr.toJSFunction('x');
+      assert.strictEqual(f(4), 5);
     });
 
     it('(sqrt y) + max(3, 1) * (x ? -y : z)', function () {


### PR DESCRIPTION
This adds a variable assignment operator `=` as per #65.

It passes all existing tests, as well as a few more I added to confirm basic functioning.

Some of points you raised in the issue are not addressed:

- concept of statements with `;` - I figured this feature can be another pull request
- expression evaluation is side-effect free - by design, variable assignment **mutates** the given `variables` object
- support should be opt-in - I wasn't sure the best way to implement this; I suppose similar to the `in` operator?
