### PR TITLE
Add statement separator

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -5,7 +5,7 @@ export default function evaluate(tokens, expr, values) {
   var n1, n2, n3;
   var f;
   function evaluateIfExpression(n) {
-    return Array.isArray(n) && n[0].type ? evaluate(n, expr, values) : n;
+    return Array.isArray(n) && n.length && n[0].type ? evaluate(n, expr, values) : n;
   }
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
@@ -24,7 +24,7 @@ export default function evaluate(tokens, expr, values) {
         nstack.push(f(n1, evaluate(n2, expr, values), values));
       } else {
         f = expr.binaryOps[item.value];
-        nstack.push(f(n1, evaluateIfExpression(n2)));
+        nstack.push(f(evaluateIfExpression(n1), evaluateIfExpression(n2)));
       }
     } else if (type === IOP3) {
       n3 = nstack.pop();

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -76,10 +76,6 @@ export default function evaluate(tokens, expr, values) {
       nstack.push(n1[item.value]);
     } else if (type === IENDSTATEMENT) {
       nstack.pop();
-      n1 = tokens[i + 1];
-      if (n1 && n1.type === IEXPR) {
-        tokens[i + 1] = createExpressionEvaluator(n1, expr, values);
-      }
     } else {
       throw new Error('invalid Expression');
     }

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1,4 +1,4 @@
-import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER } from './instruction';
+import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER, IENDSTATEMENT } from './instruction';
 
 export default function evaluate(tokens, expr, values) {
   var nstack = [];
@@ -65,6 +65,8 @@ export default function evaluate(tokens, expr, values) {
     } else if (type === IMEMBER) {
       n1 = nstack.pop();
       nstack.push(n1[item.value]);
+    } else if (type === IENDSTATEMENT) {
+      nstack.splice(0);
     } else {
       throw new Error('invalid Expression');
     }

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -4,6 +4,9 @@ export default function evaluate(tokens, expr, values) {
   var nstack = [];
   var n1, n2, n3;
   var f;
+  function evaluateIfExpression(n) {
+    return Array.isArray(n) && n[0].type ? evaluate(n, expr, values) : n;
+  }
   for (var i = 0; i < tokens.length; i++) {
     var item = tokens[i];
     var type = item.type;
@@ -21,7 +24,7 @@ export default function evaluate(tokens, expr, values) {
         nstack.push(f(n1, evaluate(n2, expr, values), values));
       } else {
         f = expr.binaryOps[item.value];
-        nstack.push(f(n1, n2));
+        nstack.push(f(n1, evaluateIfExpression(n2)));
       }
     } else if (type === IOP3) {
       n3 = nstack.pop();
@@ -66,7 +69,7 @@ export default function evaluate(tokens, expr, values) {
       n1 = nstack.pop();
       nstack.push(n1[item.value]);
     } else if (type === IENDSTATEMENT) {
-      nstack.splice(0);
+      nstack.pop();
     } else {
       throw new Error('invalid Expression');
     }
@@ -74,5 +77,5 @@ export default function evaluate(tokens, expr, values) {
   if (nstack.length > 1) {
     throw new Error('invalid Expression (parity)');
   }
-  return nstack[0] === -0 ? 0: nstack[0];
+  return nstack[0] === -0 ? 0: evaluateIfExpression(nstack[0]);
 }

--- a/src/expression-to-string.js
+++ b/src/expression-to-string.js
@@ -1,4 +1,4 @@
-import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER } from './instruction';
+import { INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER, IENDSTATEMENT } from './instruction';
 
 export default function expressionToString(tokens, toJS) {
   var nstack = [];
@@ -79,12 +79,15 @@ export default function expressionToString(tokens, toJS) {
       nstack.push(n1 + '.' + item.value);
     } else if (type === IEXPR) {
       nstack.push('(' + expressionToString(item.value, toJS) + ')');
+    } else if (type === IENDSTATEMENT) {
+      // eslint-disable no-empty
     } else {
       throw new Error('invalid Expression');
     }
   }
   if (nstack.length > 1) {
-    throw new Error('invalid Expression (parity)');
+    // throw new Error('invalid Expression (parity)');
+    nstack = [ nstack.join(',') ];
   }
   return String(nstack[0]);
 }

--- a/src/instruction.js
+++ b/src/instruction.js
@@ -7,6 +7,7 @@ export var IVARNAME = 'IVARNAME';
 export var IFUNCALL = 'IFUNCALL';
 export var IEXPR = 'IEXPR';
 export var IMEMBER = 'IMEMBER';
+export var IENDSTATEMENT = 'IENDSTATEMENT';
 
 export function Instruction(type, value) {
   this.type = type;
@@ -21,6 +22,7 @@ Instruction.prototype.toString = function () {
     case IOP3:
     case IVAR:
     case IVARNAME:
+    case IENDSTATEMENT:
       return this.value;
     case IFUNCALL:
       return 'CALL ' + this.value;

--- a/src/instruction.js
+++ b/src/instruction.js
@@ -6,6 +6,7 @@ export var IVAR = 'IVAR';
 export var IVARNAME = 'IVARNAME';
 export var IFUNCALL = 'IFUNCALL';
 export var IEXPR = 'IEXPR';
+export var IEXPREVAL = 'IEXPREVAL';
 export var IMEMBER = 'IMEMBER';
 export var IENDSTATEMENT = 'IENDSTATEMENT';
 

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -94,11 +94,7 @@ ParserState.prototype.parseUntilEndStatement = function (instr, exprInstr) {
   if (this.nextToken.type !== TEOF) {
     this.parseExpression(exprInstr);
   }
-  if (instr[0]) {
-    instr.push(new Instruction(IEXPR, exprInstr));
-  } else {
-    this.pushExpression(instr, exprInstr);
-  }
+  instr.push(new Instruction(IEXPR, exprInstr));
   return true;
 };
 

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -1,5 +1,5 @@
-import { TOP, TNUMBER, TSTRING, TPAREN, TCOMMA, TNAME } from './token';
-import { Instruction, INUMBER, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER, ternaryInstruction, binaryInstruction, unaryInstruction } from './instruction';
+import { TOP, TNUMBER, TSTRING, TPAREN, TCOMMA, TNAME, TSEMICOLON, TEOF } from './token';
+import { Instruction, INUMBER, IVAR, IVARNAME, IFUNCALL, IEXPR, IMEMBER, IENDSTATEMENT, ternaryInstruction, binaryInstruction, unaryInstruction } from './instruction';
 import contains from './contains';
 
 export function ParserState(parser, tokenStream, options) {
@@ -74,7 +74,17 @@ ParserState.prototype.parseAtom = function (instr) {
 
 ParserState.prototype.parseExpression = function (instr) {
   //this.parseConditionalExpression(instr);
+  this.parseEndStatement(instr);
+};
+
+ParserState.prototype.parseEndStatement = function (instr) {
   this.parseVariableAssignmentExpression(instr);
+  while (this.accept(TSEMICOLON)) {
+    // Ignore last semicolon to return value of last expression
+    if (this.accept(TEOF)) break;
+    instr.push(new Instruction(IENDSTATEMENT));
+    this.parseVariableAssignmentExpression(instr);
+  }
 };
 
 ParserState.prototype.parseVariableAssignmentExpression = function (instr) {

--- a/src/token-stream.js
+++ b/src/token-stream.js
@@ -1,4 +1,4 @@
-import { Token, TEOF, TOP, TNUMBER, TSTRING, TPAREN, TCOMMA, TNAME } from './token';
+import { Token, TEOF, TOP, TNUMBER, TSTRING, TPAREN, TCOMMA, TNAME, TSEMICOLON } from './token';
 
 export function TokenStream(parser, expression) {
   this.pos = 0;
@@ -40,6 +40,7 @@ TokenStream.prototype.next = function () {
       this.isString() ||
       this.isParen() ||
       this.isComma() ||
+      this.isSemicolon() ||
       this.isNamedOp() ||
       this.isConst() ||
       this.isName()) {
@@ -84,6 +85,16 @@ TokenStream.prototype.isComma = function () {
   var c = this.expression.charAt(this.pos);
   if (c === ',') {
     this.current = this.newToken(TCOMMA, ',');
+    this.pos++;
+    return true;
+  }
+  return false;
+};
+
+TokenStream.prototype.isSemicolon = function () {
+  var c = this.expression.charAt(this.pos);
+  if (c === ';') {
+    this.current = this.newToken(TSEMICOLON, ';');
     this.pos++;
     return true;
   }

--- a/src/token.js
+++ b/src/token.js
@@ -5,6 +5,7 @@ export var TSTRING = 'TSTRING';
 export var TPAREN = 'TPAREN';
 export var TCOMMA = 'TCOMMA';
 export var TNAME = 'TNAME';
+export var TSEMICOLON = 'TSEMICOLON';
 
 export function Token(type, value, index) {
   this.type = type;

--- a/test/expression.js
+++ b/test/expression.js
@@ -147,6 +147,11 @@ describe('Expression', function () {
       assert.strictEqual(parser.evaluate('x=3;y=4;z=x*y;'), 12);
     });
 
+    it('1 + (( 3 ; 4 ) + 5)', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.evaluate('1 + (( 3 ; 4 ) + 5)'), 10);
+    });
+
     it('2+(x=3;y=4;z=x*y)+5', function () {
       var parser = new Parser({ operators: { assignment: true } });
       assert.strictEqual(parser.evaluate('2+(x=3;y=4;z=x*y)+5'), 19);
@@ -501,16 +506,16 @@ describe('Expression', function () {
     });
 
     it('3 ; 2 ; 1', function () {
-      assert.strictEqual(parser.parse('3 ; 2 ; 1').toString(), '3,(2,1)');
+      assert.strictEqual(parser.parse('3 ; 2 ; 1').toString(), '(3,(2,1))');
     });
 
     it('3 ; 2 ; 1 ;', function () {
-      assert.strictEqual(parser.parse('3 ; 2 ; 1 ;').toString(), '3,(2,(1))');
+      assert.strictEqual(parser.parse('3 ; 2 ; 1 ;').toString(), '(3,(2,(1)))');
     });
 
     it('x = 3 ; y = 4 ; z = x * y', function () {
       var parser = new Parser({ operators: { assignment: true } });
-      assert.strictEqual(parser.parse('x = 3 ; y = 4 ; z = x * y').toString(), '(x = (3)),((y = (4)),(z = ((x * y))))');
+      assert.strictEqual(parser.parse('x = 3 ; y = 4 ; z = x * y').toString(), '((x = (3)),((y = (4)),(z = ((x * y)))))');
     });
 
     it('2+(x=3;y=4;z=x*y)+5', function () {

--- a/test/expression.js
+++ b/test/expression.js
@@ -147,6 +147,11 @@ describe('Expression', function () {
       assert.strictEqual(parser.evaluate('x=3;y=4;z=x*y;'), 12);
     });
 
+    it('2+(x=3;y=4;z=x*y)+5', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.evaluate('2+(x=3;y=4;z=x*y)+5'), 19);
+    });
+
     it('should fail trying to call a non-function', function () {
       assert.throws(function () { Parser.evaluate('f()', { f: 2 }); }, Error);
     });

--- a/test/expression.js
+++ b/test/expression.js
@@ -501,16 +501,21 @@ describe('Expression', function () {
     });
 
     it('3 ; 2 ; 1', function () {
-      assert.strictEqual(parser.parse('3 ; 2 ; 1').toString(), '3,2,1');
+      assert.strictEqual(parser.parse('3 ; 2 ; 1').toString(), '3,(2,1)');
     });
 
     it('3 ; 2 ; 1 ;', function () {
-      assert.strictEqual(parser.parse('3 ; 2 ; 1 ;').toString(), '3,2,1');
+      assert.strictEqual(parser.parse('3 ; 2 ; 1 ;').toString(), '3,(2,(1))');
     });
 
     it('x = 3 ; y = 4 ; z = x * y', function () {
       var parser = new Parser({ operators: { assignment: true } });
-      assert.strictEqual(parser.parse('x = 3 ; y = 4 ; z = x * y').toString(), '(x = (3)),(y = (4)),(z = ((x * y)))');
+      assert.strictEqual(parser.parse('x = 3 ; y = 4 ; z = x * y').toString(), '(x = (3)),((y = (4)),(z = ((x * y))))');
+    });
+
+    it('2+(x=3;y=4;z=x*y)+5', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.parse('2+(x=3;y=4;z=x*y)+5').toString(), '((2 + ((x = (3)),((y = (4)),(z = ((x * y)))))) + 5)');
     });
 
     it('\'as\' || \'df\'', function () {

--- a/test/expression.js
+++ b/test/expression.js
@@ -129,6 +129,24 @@ describe('Expression', function () {
       assert.strictEqual(3, obj.z);
     });
 
+    it('3 ; 2 ; 1', function () {
+      assert.strictEqual(Parser.evaluate('3 ; 2 ; 1'), 1);
+    });
+
+    it('3 ; 2 ; 1 ;', function () {
+      assert.strictEqual(Parser.evaluate('3 ; 2 ; 1 ;'), 1);
+    });
+
+    it('x = 3 ; y = 4 ; z = x * y', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.evaluate('x = 3 ; y = 4 ; z = x * y'), 12);
+    });
+
+    it('x=3;y=4;z=x*y;', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.evaluate('x=3;y=4;z=x*y;'), 12);
+    });
+
     it('should fail trying to call a non-function', function () {
       assert.throws(function () { Parser.evaluate('f()', { f: 2 }); }, Error);
     });
@@ -477,6 +495,19 @@ describe('Expression', function () {
       assert.strictEqual(parser.parse('x = y = x + 1').toString(), '(x = ((y = ((x + 1)))))');
     });
 
+    it('3 ; 2 ; 1', function () {
+      assert.strictEqual(parser.parse('3 ; 2 ; 1').toString(), '3,2,1');
+    });
+
+    it('3 ; 2 ; 1 ;', function () {
+      assert.strictEqual(parser.parse('3 ; 2 ; 1 ;').toString(), '3,2,1');
+    });
+
+    it('x = 3 ; y = 4 ; z = x * y', function () {
+      var parser = new Parser({ operators: { assignment: true } });
+      assert.strictEqual(parser.parse('x = 3 ; y = 4 ; z = x * y').toString(), '(x = (3)),(y = (4)),(z = ((x * y)))');
+    });
+
     it('\'as\' || \'df\'', function () {
       assert.strictEqual(parser.parse('\'as\' || \'df\'').toString(), '("as" || "df")');
     });
@@ -516,6 +547,12 @@ describe('Expression', function () {
       var expr = parser.parse('x = x + 1');
       var f = expr.toJSFunction('x');
       assert.strictEqual(f(4), 5);
+    });
+
+    it('y = 4 ; z = x < 5 ? x * y : x / y', function () {
+      var expr = parser.parse('y = 4 ; z = x < 5 ? x * y : x / y');
+      var f = expr.toJSFunction('x');
+      assert.strictEqual(f(3), 12);
     });
 
     it('(sqrt y) + max(3, 1) * (x ? -y : z)', function () {
@@ -702,5 +739,6 @@ describe('Expression', function () {
       assert.strictEqual(parser.parse('(x - 1)!').toJSFunction('x')(5), 24);
       assert.strictEqual(parser.parse('(x - 1)!').toJSFunction('x')(6), 120);
     });
+
   });
 });


### PR DESCRIPTION
This adds a statement separator `;` as per #65.

A few notes on implementation:

- During parsing, it explicitly ignores the last statement separator. This is so `3;2;1;` returns the last value/expression, same as `3;2;1`.
- During evaluation, the statement separator pops the stack so a new expression can start.
- For `expressionToString()` and `toJSFunction()`, statements are joined with `,` which conveniently returns the last value as intended.
