### PR TITLE
include source files in npm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist/",
+    "src/",
     "parser.d.ts"
   ],
   "repository": {


### PR DESCRIPTION
including the source files would be useful if one wants to use and include a customize bundle of `expr-eval` in a project.

this would allow doing partial imports such as 
```js
import { Expression } from 'expr-eval/src/expression';
```
which are currently impossible.