### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -41,6 +41,9 @@ export default function evaluate(tokens, expr, values) {
         nstack.push(f(resolveExpression(n1, values), resolveExpression(n2, values), resolveExpression(n3, values)));
       }
     } else if (type === IVAR) {
+      if (/^__proto__|prototype|constructor$/.test(item.value)) {
+        throw new Error('prototype access detected');
+      }
       if (item.value in expr.functions) {
         nstack.push(expr.functions[item.value]);
       } else if (item.value in expr.unaryOps && expr.parser.isOperatorEnabled(item.value)) {


### PR DESCRIPTION
@Yoshino-s (https://huntr.dev/users/Yoshino-s) has fixed a potential Prototype Pollution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/expr-eval/pull/1

If you are happy with this disclosure, we would love to get a CVE assigned to the vulnerability. Feel free to credit @Yoshino-s, the discloser found in the bounty URL (below) and @huntr-helper.

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-expr-eval/

### ⚙️ Description *

With speficific input attckers can define properties on prototype, which will lead to prototype pollution.

> Need node version>=12.0.0, which introduce `Object.fromEntries`

### 💻 Technical Description *

when we access global value, it will just search by `item.value in expr.functions`, with which we can also access to `prototype`, `__proto__`, `constructor`, and assign some properties on it.

### 🐛 Proof of Concept (PoC) *

```js
// PoC.js
const { Parser } = require('expr-eval');
const o = {};
console.log("o.a=", o.a); // o.a= undefined
const res = Parser.evaluate('Object=constructor;a=Object.fromEntries([["a","polluted"]]);Object.assign(__proto__, a)');
console.log("o.a=", o.a); // o.a= polluted
```

### 🔥 Proof of Fix (PoF) *

```js
// PoF.js
const { Parser } = require('expr-eval');
const o = {};
console.log("o.a=", o.a); // o.a= undefined
const res = Parser.evaluate('Object=constructor;a=Object.fromEntries([["a","polluted"]]);Object.assign(__proto__, a)');
console.log("o.a=", o.a); // o.a= undefined
```
