### PR TITLE
allow functional override of "." for property read

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -100,7 +100,12 @@ export default function evaluate(tokens, expr, values) {
       nstack.push(item);
     } else if (type === IMEMBER) {
       n1 = nstack.pop();
-      nstack.push(n1[item.value]);
+      f = expr.binaryOps['.']
+      if(f.apply && f.call) {
+        nstack.push(f.apply(undefined, [n1, item.value]));
+      } else {
+        throw new Error(f + ' is not a function');
+      }
     } else if (type === IENDSTATEMENT) {
       nstack.pop();
     } else if (type === IARRAY) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -254,6 +254,10 @@ export function arrayIndex(array, index) {
   return array[index | 0];
 }
 
+export function member(object, name) {
+  return object[name];
+}
+
 export function max(array) {
   if (arguments.length === 1 && Array.isArray(array)) {
     return Math.max.apply(Math, array);

--- a/src/parser.js
+++ b/src/parser.js
@@ -37,6 +37,7 @@ import {
   roundTo,
   setVar,
   arrayIndex,
+  member,
   max,
   min,
   arrayMap,
@@ -108,8 +109,13 @@ export function Parser(options) {
     or: orOperator,
     'in': inOperator,
     '=': setVar,
-    '[': arrayIndex
+    '[': arrayIndex,
+    '.': member
   };
+
+  if(this.options.overrideMember) {
+    this.binaryOps['.'] = this.options.overrideMember
+  }
 
   this.ternaryOps = {
     '?': condition

--- a/src/simplify.js
+++ b/src/simplify.js
@@ -1,4 +1,5 @@
 import { Instruction, INUMBER, IOP1, IOP2, IOP3, IVAR, IVARNAME, IEXPR, IMEMBER, IARRAY } from './instruction';
+import { member } from './functions';
 
 export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values) {
   var nstack = [];
@@ -46,7 +47,7 @@ export default function simplify(tokens, unaryOps, binaryOps, ternaryOps, values
         newexpression.push(nstack.shift());
       }
       newexpression.push(new Instruction(IEXPR, simplify(item.value, unaryOps, binaryOps, ternaryOps, values)));
-    } else if (type === IMEMBER && nstack.length > 0) {
+    } else if (type === IMEMBER && nstack.length > 0 && member === binaryOps['.']) { //check if member overridden
       n1 = nstack.pop();
       nstack.push(new Instruction(INUMBER, n1.value[item.value]));
     } /* else if (type === IARRAY && nstack.length >= item.value) {

--- a/test/functions.js
+++ b/test/functions.js
@@ -485,4 +485,17 @@ describe('Functions', function () {
       assert.strictEqual(parser.evaluate('sum([1, 2])'), 3);
     });
   });
+  
+  describe('member(value,name)', function () {
+    it('basic', function () {
+      var parser = new Parser();
+      assert.strictEqual(parser.evaluate('a.something', {a : {something: 123}}), 123);
+    });
+    
+    it('able to override', function () {
+      var parser = new Parser({overrideMember:function(v,n) { return 456; }});
+      assert.strictEqual(parser.evaluate('a.anything', {a : {}}), 456);
+    });
+  });    
+
 });


### PR DESCRIPTION
use new Parser({overrideMember:function(value,memberName){...}}) to provide a function to override member function.

Parsers with overridden "." will also not simply "." expressions