### PR TITLE
fix incorrect return types

### DIFF
--- a/parser.d.ts
+++ b/parser.d.ts
@@ -65,14 +65,14 @@ export class Parser {
     functions: any;
     consts: any;
     parse(expression: string): Expression;
-    evaluate(expression: string, values?: Value): number;
+    evaluate(expression: string, values?: Value): string;
     static parse(expression: string): Expression;
-    static evaluate(expression: string, values?: Value): number;
+    static evaluate(expression: string, values?: Value): string;
 }
 
 export interface Expression {
     simplify(values?: Value): Expression;
-    evaluate(values?: Value): any;
+    evaluate(values?: Value): string;
     substitute(variable: string, value: Expression | string | number): Expression;
     symbols(options?: { withMembers?: boolean }): string[];
     variables(options?: { withMembers?: boolean }): string[];


### PR DESCRIPTION
This is what I see at runtime:

```js
const formulaResult = Parser.evaluate(this.durationFormula, formulaInputs)
console.log('typeof result:', typeof formulaResult) // string
```

The return of evaluate was `number`, but I see strings being returned.

Why was `Expression#evaluate`'s return type `any`? Does it return things other than strings?